### PR TITLE
Remove the credentials

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -19,13 +19,13 @@
 
 // ** Réglages MySQL - Votre hébergeur doit vous fournir ces informations. ** //
 /** Nom de la base de données de WordPress. */
-define('DB_NAME', 'domestication');
+define('DB_NAME', '<DB_NAME>');
 
 /** Utilisateur de la base de données MySQL. */
-define('DB_USER', 'domestication');
+define('DB_USER', '<DB_USER>');
 
 /** Mot de passe de la base de données MySQL. */
-define('DB_PASSWORD', 'mVSrGSEYGvFBHZR7');
+define('DB_PASSWORD', '<DB_PASSWORD>');
 
 /** Adresse de l'hébergement MySQL. */
 define('DB_HOST', 'localhost');


### PR DESCRIPTION
Credentials should be hidden because it can allow an attacker to get information about the website